### PR TITLE
feat: load latest word quiz when today's is missing

### DIFF
--- a/app/pages/english/word-quiz.tsx
+++ b/app/pages/english/word-quiz.tsx
@@ -32,18 +32,56 @@ export default function WordQuizPage() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    fetch(`${baseUrl}/word-quiz`)
-      .then((res) => res.json())
-      .then((data: QuizResponse) => {
-        const items: QuizItem[] = [
-          ...(data.synonyms || []).map((q) => ({ ...q, kind: "synonyms" })),
-          ...(data.antonyms || []).map((q) => ({ ...q, kind: "antonyms" })),
-          ...(data.wordpairs || []).map((q) => ({ ...q, kind: "wordpairs" })),
-        ];
-        setQuiz(items);
-        setDate(data._metadata?.date || "");
-        setAnswers(Array(items.length).fill(null));
-      });
+    const setupQuiz = (data: QuizResponse) => {
+      const items: QuizItem[] = [
+        ...(data.synonyms || []).map((q) => ({ ...q, kind: "synonyms" })),
+        ...(data.antonyms || []).map((q) => ({ ...q, kind: "antonyms" })),
+        ...(data.wordpairs || []).map((q) => ({ ...q, kind: "wordpairs" })),
+      ];
+      setQuiz(items);
+      setDate(data._metadata?.date || "");
+      setAnswers(Array(items.length).fill(null));
+    };
+
+    const loadQuiz = async () => {
+      try {
+        const res = await fetch(`${baseUrl}/word-quiz`);
+        if (res.ok) {
+          const data: QuizResponse = await res.json();
+          const hasItems =
+            (data.synonyms && data.synonyms.length > 0) ||
+            (data.antonyms && data.antonyms.length > 0) ||
+            (data.wordpairs && data.wordpairs.length > 0);
+          if (hasItems) {
+            setupQuiz(data);
+            return;
+          }
+        }
+      } catch (e) {
+        console.error(e);
+      }
+
+      try {
+        const listRes = await fetch(`${baseUrl}/word-quiz-list`);
+        if (!listRes.ok) return;
+        const listData = (await listRes.json()) as
+          | { items: { date: string }[] }
+          | { date: string }[];
+        const listItems = Array.isArray(listData)
+          ? listData
+          : listData.items;
+        const latest = listItems?.[0];
+        if (!latest?.date) return;
+        const latestRes = await fetch(`${baseUrl}/word-quiz/${latest.date}`);
+        if (!latestRes.ok) return;
+        const data: QuizResponse = await latestRes.json();
+        setupQuiz(data);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    void loadQuiz();
   }, []);
 
   const handleSelect = (option: number) => {

--- a/app/pages/english/word-quiz.tsx
+++ b/app/pages/english/word-quiz.tsx
@@ -45,23 +45,6 @@ export default function WordQuizPage() {
 
     const loadQuiz = async () => {
       try {
-        const res = await fetch(`${baseUrl}/word-quiz`);
-        if (res.ok) {
-          const data: QuizResponse = await res.json();
-          const hasItems =
-            (data.synonyms && data.synonyms.length > 0) ||
-            (data.antonyms && data.antonyms.length > 0) ||
-            (data.wordpairs && data.wordpairs.length > 0);
-          if (hasItems) {
-            setupQuiz(data);
-            return;
-          }
-        }
-      } catch (e) {
-        console.error(e);
-      }
-
-      try {
         const listRes = await fetch(`${baseUrl}/word-quiz-list`);
         if (!listRes.ok) return;
         const listData = (await listRes.json()) as
@@ -70,12 +53,21 @@ export default function WordQuizPage() {
         const listItems = Array.isArray(listData)
           ? listData
           : listData.items;
-        const latest = listItems?.[0];
+        if (!listItems || listItems.length === 0) return;
+        const latest = listItems.reduce((prev, cur) =>
+          new Date(cur.date) > new Date(prev.date) ? cur : prev
+        );
         if (!latest?.date) return;
         const latestRes = await fetch(`${baseUrl}/word-quiz/${latest.date}`);
         if (!latestRes.ok) return;
         const data: QuizResponse = await latestRes.json();
-        setupQuiz(data);
+        const hasItems =
+          (data.synonyms && data.synonyms.length > 0) ||
+          (data.antonyms && data.antonyms.length > 0) ||
+          (data.wordpairs && data.wordpairs.length > 0);
+        if (hasItems) {
+          setupQuiz(data);
+        }
       } catch (e) {
         console.error(e);
       }

--- a/app/pages/english/word-quiz.tsx
+++ b/app/pages/english/word-quiz.tsx
@@ -45,20 +45,15 @@ export default function WordQuizPage() {
 
     const loadQuiz = async () => {
       try {
-        const listRes = await fetch(`${baseUrl}/word-quiz-list`);
+        const listRes = await fetch(`${baseUrl}/word-quiz/list`);
         if (!listRes.ok) return;
-        const listData = (await listRes.json()) as
-          | { items: { date: string }[] }
-          | { date: string }[];
-        const listItems = Array.isArray(listData)
-          ? listData
-          : listData.items;
+        const listData = (await listRes.json())
+        const listItems = listData.items
         if (!listItems || listItems.length === 0) return;
         const latest = listItems.reduce((prev, cur) =>
-          new Date(cur.date) > new Date(prev.date) ? cur : prev
+          new Date(cur) > new Date(prev) ? cur : prev
         );
-        if (!latest?.date) return;
-        const latestRes = await fetch(`${baseUrl}/word-quiz/${latest.date}`);
+        const latestRes = await fetch(`${baseUrl}/word-quiz/${latest}`);
         if (!latestRes.ok) return;
         const data: QuizResponse = await latestRes.json();
         const hasItems =


### PR DESCRIPTION
## Summary
- load today's word quiz if available
- fall back to the most recent word quiz from list when today's data is missing

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b4e112c24c8326a5d5c71e37f5636f