### PR TITLE
Refine redesign to navigation and top bar

### DIFF
--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ArrowLeft, Home, Menu } from "lucide-react"
+import { ArrowLeft, Home, Menu, Bell, User, BookOpen } from "lucide-react"
 
 interface BackHeaderProps {
   title?: string;
@@ -11,7 +11,7 @@ interface BackHeaderProps {
 }
 
 export default function Header({
-  title = "온느수학",
+  title = "학습앱",
   onBack,
   showHome = true,
   onMenu,
@@ -29,34 +29,43 @@ export default function Header({
   }
 
   return (
-    <header className="bg-white/80 backdrop-blur-sm border-b-2 border-gray-200 sticky top-0 z-50 shadow-sm">
-      <div className="max-w-6xl mx-auto px-2 sm:px-4 py-2 sm:py-3">
+    <header className="bg-white/80 backdrop-blur-md border-b border-gray-100 sticky top-0 z-50 shadow-sm">
+      <div className="max-w-6xl mx-auto px-4 py-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             {onMenu && (
               <Menu
-                className="w-5 h-5 sm:w-6 sm:h-6 cursor-pointer"
+                className="w-6 h-6 cursor-pointer"
                 onClick={onMenu}
               />
             )}
-            <ArrowLeft
-              className="w-5 h-5 sm:w-6 sm:h-6 cursor-pointer"
-              onClick={handleBack}
-            />
+            {onBack && (
+              <ArrowLeft
+                className="w-6 h-6 cursor-pointer"
+                onClick={handleBack}
+              />
+            )}
           </div>
 
-          {/* Title */}
-          <div className="text-center flex-1 mx-4">
-            <h1 className="text-lg sm:text-xl font-bold text-gray-800">{title}</h1>
+          <div className="flex items-center gap-2 text-center flex-1 justify-center">
+            <BookOpen className="w-5 h-5 text-indigo-500" />
+            <h1 className="text-lg font-bold text-gray-800">{title}</h1>
           </div>
 
-          {/* Home Button */}
-          {showHome && (
-            <Home
-              className="w-5 h-5 sm:w-6 sm:h-6 cursor-pointer"
-              onClick={handleHome}
-            />
-          )}
+          <div className="flex items-center gap-3">
+            {showHome && (
+              <Home
+                className="w-5 h-5 cursor-pointer"
+                onClick={handleHome}
+              />
+            )}
+            <Bell className="w-5 h-5 text-gray-600" />
+            <div className="p-[2px] rounded-full bg-gradient-to-br from-indigo-400 to-purple-500">
+              <div className="bg-white rounded-full p-1">
+                <User className="w-4 h-4 text-indigo-600" />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </header>

--- a/app/components/layout/NavigationDrawer.tsx
+++ b/app/components/layout/NavigationDrawer.tsx
@@ -16,28 +16,33 @@ export default function NavigationDrawer({ open, onClose }: NavigationDrawerProp
         onClick={onClose}
       />
       <nav
-        className={`absolute left-0 top-0 h-full w-64 bg-white shadow-lg transform transition-transform ${
+        className={`absolute left-0 top-0 h-full w-64 bg-white rounded-r-2xl shadow-xl transform transition-transform ${
           open ? "translate-x-0" : "-translate-x-full"
         }`}
       >
-        <div className="p-4 space-y-4">
-          <button onClick={onClose} className="flex items-center gap-2">
-            <X className="w-5 h-5" /> Close
+        <div className="p-6 space-y-6">
+          <button onClick={onClose} className="flex items-center gap-2 text-gray-600">
+            <X className="w-5 h-5" /> 닫기
           </button>
-          <ul className="space-y-2">
+          <ul className="space-y-4 text-lg">
             <li>
-              <Link to="/" onClick={onClose} className="block py-1">
-                Home
+              <Link to="/" onClick={onClose} className="block hover:text-indigo-600">
+                홈
               </Link>
             </li>
             <li>
-              <Link to="/math" onClick={onClose} className="block py-1">
-                Math
+              <Link to="/english" onClick={onClose} className="block hover:text-indigo-600">
+                영어
               </Link>
             </li>
             <li>
-              <Link to="/english" onClick={onClose} className="block py-1">
-                English
+              <Link to="/math" onClick={onClose} className="block hover:text-indigo-600">
+                수학
+              </Link>
+            </li>
+            <li>
+              <Link to="/settings" onClick={onClose} className="block hover:text-indigo-600">
+                설정
               </Link>
             </li>
           </ul>


### PR DESCRIPTION
## Summary
- restore global components to original styles
- keep updated gradients and layout only in header and navigation drawer

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3f21b1db48326bf87a98990d7fe56