### PR TITLE
feat: style header and navigation drawer with material design

### DIFF
--- a/app/components/educational-toys-hub.tsx
+++ b/app/components/educational-toys-hub.tsx
@@ -188,19 +188,6 @@ export default function EducationalToysHub({ category }: EducationalToysHubProps
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-yellow-50 p-4">
       <div className="max-w-6xl mx-auto">
-        {/* Header */}
-        <div className="text-center mb-8">
-          <div className="flex justify-center items-center gap-3 mb-4">
-            <Star className="w-6 h-6 sm:w-8 sm:h-8 text-yellow-500" />
-            <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-800">교육 놀이터</h1>
-            <Star className="w-6 h-6 sm:w-8 sm:h-8 text-yellow-500" />
-          </div>
-          <p className="text-lg sm:text-xl text-gray-600 mb-2">Educational Playground</p>
-          <p className="text-base sm:text-lg text-gray-500">재미있게 배우는 어린이 학습 게임</p>
-          <div className="flex justify-center mt-4">
-            <Heart className="w-6 h-6 text-red-400 animate-pulse" />
-          </div>
-        </div>
 
         {/* Toy Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -12,7 +12,7 @@ interface BackHeaderProps {
 }
 
 export default function Header({
-  title = "온느수학",
+  title = "교육놀이터",
   onBack,
   showHome = true,
   onMenu,

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ArrowLeft, Home, Menu } from "lucide-react"
+import { Button } from "@/components/ui/button"
 
 interface BackHeaderProps {
   title?: string;
@@ -29,35 +30,41 @@ export default function Header({
   }
 
   return (
-    <header className="bg-white/80 backdrop-blur-sm border-b-2 border-gray-200 sticky top-0 z-50 shadow-sm">
-      <div className="max-w-6xl mx-auto px-2 sm:px-4 py-2 sm:py-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            {onMenu && (
-              <Menu
-                className="w-5 h-5 sm:w-6 sm:h-6 cursor-pointer"
-                onClick={onMenu}
-              />
-            )}
-            <ArrowLeft
-              className="w-5 h-5 sm:w-6 sm:h-6 cursor-pointer"
-              onClick={handleBack}
-            />
-          </div>
-
-          {/* Title */}
-          <div className="text-center flex-1 mx-4">
-            <h1 className="text-lg sm:text-xl font-bold text-gray-800">{title}</h1>
-          </div>
-
-          {/* Home Button */}
-          {showHome && (
-            <Home
-              className="w-5 h-5 sm:w-6 sm:h-6 cursor-pointer"
-              onClick={handleHome}
-            />
+    <header className="sticky top-0 z-50 bg-primary text-primary-foreground shadow-md">
+      <div className="max-w-6xl mx-auto flex h-14 items-center justify-between px-4">
+        <div className="flex items-center gap-1">
+          {onMenu && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onMenu}
+              aria-label="메뉴 열기"
+            >
+              <Menu className="h-5 w-5" />
+            </Button>
           )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleBack}
+            aria-label="뒤로 가기"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
         </div>
+        <h1 className="text-lg font-medium">{title}</h1>
+        {showHome ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleHome}
+            aria-label="홈으로"
+          >
+            <Home className="h-5 w-5" />
+          </Button>
+        ) : (
+          <span className="w-5" />
+        )}
       </div>
     </header>
   )

--- a/app/components/layout/NavigationDrawer.tsx
+++ b/app/components/layout/NavigationDrawer.tsx
@@ -2,6 +2,7 @@
 
 import { Link } from "react-router";
 import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface NavigationDrawerProps {
   open: boolean;
@@ -12,37 +13,62 @@ export default function NavigationDrawer({ open, onClose }: NavigationDrawerProp
   return (
     <div className={`fixed inset-0 z-40 ${open ? "" : "pointer-events-none"}`}>
       <div
-        className={`absolute inset-0 bg-black/40 transition-opacity ${open ? "opacity-100" : "opacity-0"}`}
+        className={`absolute inset-0 bg-black/40 transition-opacity duration-300 ${open ? "opacity-100" : "opacity-0"}`}
         onClick={onClose}
+        aria-hidden="true"
       />
-      <nav
-        className={`absolute left-0 top-0 h-full w-64 bg-white shadow-lg transform transition-transform ${
+      <aside
+        className={`absolute left-0 top-0 h-full w-64 bg-white shadow-xl transform transition-transform duration-300 ${
           open ? "translate-x-0" : "-translate-x-full"
         }`}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="p-4 space-y-4">
-          <button onClick={onClose} className="flex items-center gap-2">
-            <X className="w-5 h-5" /> Close
-          </button>
-          <ul className="space-y-2">
-            <li>
-              <Link to="/" onClick={onClose} className="block py-1">
-                Home
-              </Link>
-            </li>
-            <li>
-              <Link to="/math" onClick={onClose} className="block py-1">
-                Math
-              </Link>
-            </li>
-            <li>
-              <Link to="/english" onClick={onClose} className="block py-1">
-                English
-              </Link>
-            </li>
-          </ul>
+          <div className="flex items-center justify-between">
+            <span className="text-lg font-medium">Menu</span>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              aria-label="닫기"
+            >
+              <X className="h-5 w-5" />
+            </Button>
+          </div>
+          <nav>
+            <ul className="space-y-1">
+              <li>
+                <Link
+                  to="/"
+                  onClick={onClose}
+                  className="block rounded px-4 py-2 text-sm hover:bg-primary/10"
+                >
+                  Home
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/math"
+                  onClick={onClose}
+                  className="block rounded px-4 py-2 text-sm hover:bg-primary/10"
+                >
+                  Math
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/english"
+                  onClick={onClose}
+                  className="block rounded px-4 py-2 text-sm hover:bg-primary/10"
+                >
+                  English
+                </Link>
+              </li>
+            </ul>
+          </nav>
         </div>
-      </nav>
+      </aside>
     </div>
   );
 }

--- a/app/components/layout/NavigationDrawer.tsx
+++ b/app/components/layout/NavigationDrawer.tsx
@@ -40,15 +40,6 @@ export default function NavigationDrawer({ open, onClose }: NavigationDrawerProp
             <ul className="space-y-2">
               <li>
                 <Link
-                  to="/"
-                  onClick={onClose}
-                  className="block rounded px-6 py-3 text-lg font-medium hover:bg-primary/10"
-                >
-                  홈
-                </Link>
-              </li>
-              <li>
-                <Link
                   to="/math"
                   onClick={onClose}
                   className="block rounded px-6 py-3 text-lg font-medium hover:bg-primary/10"

--- a/app/components/layout/NavigationDrawer.tsx
+++ b/app/components/layout/NavigationDrawer.tsx
@@ -26,7 +26,7 @@ export default function NavigationDrawer({ open, onClose }: NavigationDrawerProp
       >
         <div className="p-4 space-y-4">
           <div className="flex items-center justify-between">
-            <span className="text-lg font-medium">Menu</span>
+            <span className="text-xl font-medium">메뉴</span>
             <Button
               variant="ghost"
               size="icon"
@@ -37,32 +37,32 @@ export default function NavigationDrawer({ open, onClose }: NavigationDrawerProp
             </Button>
           </div>
           <nav>
-            <ul className="space-y-1">
+            <ul className="space-y-2">
               <li>
                 <Link
                   to="/"
                   onClick={onClose}
-                  className="block rounded px-4 py-2 text-sm hover:bg-primary/10"
+                  className="block rounded px-6 py-3 text-lg font-medium hover:bg-primary/10"
                 >
-                  Home
+                  홈
                 </Link>
               </li>
               <li>
                 <Link
                   to="/math"
                   onClick={onClose}
-                  className="block rounded px-4 py-2 text-sm hover:bg-primary/10"
+                  className="block rounded px-6 py-3 text-lg font-medium hover:bg-primary/10"
                 >
-                  Math
+                  수학
                 </Link>
               </li>
               <li>
                 <Link
                   to="/english"
                   onClick={onClose}
-                  className="block rounded px-4 py-2 text-sm hover:bg-primary/10"
+                  className="block rounded px-6 py-3 text-lg font-medium hover:bg-primary/10"
                 >
-                  English
+                  영어
                 </Link>
               </li>
             </ul>

--- a/app/components/subject-selection-hub.tsx
+++ b/app/components/subject-selection-hub.tsx
@@ -38,17 +38,12 @@ export default function SubjectSelectionHub() {
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-yellow-50 p-4">
       <div className="max-w-4xl mx-auto">
         <div className="text-center mb-8">
-          <div className="flex justify-center items-center gap-3 mb-4">
+          <div className="flex justify-center items-center gap-3 mt-8 mb-12">
             <Star className="w-6 h-6 sm:w-8 sm:h-8 text-yellow-500" />
             <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-800">
               어떤 과목을 배울까요?
             </h1>
             <Star className="w-6 h-6 sm:w-8 sm:h-8 text-yellow-500" />
-          </div>
-          <p className="text-lg sm:text-xl text-gray-600 mb-2">Choose a Subject</p>
-          <p className="text-base sm:text-lg text-gray-500">재미있는 학습을 시작해요</p>
-          <div className="flex justify-center mt-4">
-            <Heart className="w-6 h-6 text-red-400 animate-pulse" />
           </div>
         </div>
 

--- a/app/pages/english/word-quiz.tsx
+++ b/app/pages/english/word-quiz.tsx
@@ -47,12 +47,13 @@ export default function WordQuizPage() {
       try {
         const listRes = await fetch(`${baseUrl}/word-quiz/list`);
         if (!listRes.ok) return;
-        const listData = (await listRes.json())
-        const listItems = listData.items
-        if (!listItems || listItems.length === 0) return;
-        const latest = listItems.reduce((prev, cur) =>
-          new Date(cur) > new Date(prev) ? cur : prev
-        );
+        const listData = await listRes.json()
+        const listItems: string[] = listData.items || []
+        if (!listItems || listItems.length === 0) return
+        const latest = listItems.reduce(
+          (prev: string, cur: string) =>
+            new Date(cur) > new Date(prev) ? cur : prev
+        )
         const latestRes = await fetch(`${baseUrl}/word-quiz/${latest}`);
         if (!latestRes.ok) return;
         const data: QuizResponse = await latestRes.json();


### PR DESCRIPTION
## Summary
- restyle header using primary color and icon buttons for a material-like top app bar
- redesign navigation drawer with slide-in panel and material menu styling
- fix word quiz type error

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb77d3901883268654d6ac4fdf539d